### PR TITLE
fix yield-bearing PT pricing if it expire

### DIFF
--- a/test/strategies/USDCPendleStrategyTest.t.sol
+++ b/test/strategies/USDCPendleStrategyTest.t.sol
@@ -150,12 +150,7 @@ contract USDCPendleStrategyTest is BasePendleStrategyTest {
             swapper.getPriceFromChainLinkWithHeartbeat(YIELD_TOKEN_FEED1, uint32(Constants.ONE_YEAR));
         assertTrue(
             _assertApproximateEq(
-                _ptPrice,
-                (
-                    uint256(_yieldUSDPrice) * IERC4626Vault(UNDERLYING_YIELD_ADDR1).convertToAssets(Constants.ONE_ETHER)
-                        * Constants.ONE_ETHER / (uint256(_usdcUSDPrice) * Constants.ONE_ETHER)
-                ),
-                BIGGER_TOLERANCE
+                _ptPrice, uint256(_yieldUSDPrice) * Constants.ONE_ETHER / uint256(_usdcUSDPrice), BIGGER_TOLERANCE
             )
         );
     }


### PR DESCRIPTION
the purpose of this change is to fix the pricing of yield-bearing PT after it expires.

For example, when [`sUSDe PT`](https://app.pendle.finance/trade/markets/0xa36b60a14a1a5247912584768c6e53e1a269a9f7/swap?view=pt&chain=ethereum) expires, 1 PT is equivalent to `1 USDe staked in Ethena`, not `sUSDe` in any way.

As a result, we should use on-chain oracle of `USDe` instead of fetching the exchange rate from `sUSDe` after PT expire.

This mechanism should apply to all yield-bearing PT, e.g., ERC4626 based underlying asset such as [`wstUSR`](https://app.pendle.finance/trade/markets/0x09fa04aac9c6d1c6131352ee950cd67ecc6d4fb9/swap?view=pt&chain=ethereum) or [`sUSDf`](https://app.pendle.finance/trade/markets/0x45f163e583d34b8e276445dd3da9ae077d137d72/swap?view=pt&chain=ethereum)